### PR TITLE
Provide dates for account creation and server join

### DIFF
--- a/src/commands/member_info.rs
+++ b/src/commands/member_info.rs
@@ -8,10 +8,7 @@ use serenity::{
 #[command]
 #[aliases("minfo", "memberinfo")]
 async fn get_member_info(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
-    let guild_id = match msg.guild_id {
-        Some(id) => id,
-        None => return Ok(()),
-    };
+    let guild_id = msg.guild_id.unwrap();
 
     let member = if args.is_empty() {
         msg.member(ctx).await?


### PR DESCRIPTION
This improves the `get_member_info` command to include the date of the creation of the member's account, and the date since they joined the guild. While unrelated to the goal of the pull request, the quality of the command's code has also been improved to decrease the chances of panics and by using a more appropriate alternative to `map_or` to avoid needlessly allocating a `String` and using a closure that performs nothing on the value.

I was not sure how the dates should be formatted exactly, so I went with the RFC 2822 date and time format, which `chrono` conveniently provides [a conversion method for][rfc2822] on its `DateTime` type.

**Note**: This has not been tested as I couldn't be bothered to set up a PostgreSQL database on my system just to test a simple change. However, it should work as advertised.

[rfc2822]: https://docs.rs/chrono/0.4.19/chrono/struct.DateTime.html#method.to_rfc2822